### PR TITLE
Added testem as a test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 npm-debug.log*
 node_modules
+.nvmrc
+testem.log

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/san650/ceibo/issues",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node ./node_modules/testem/testem"
   },
   "repository": {
     "type": "git",
@@ -19,6 +19,7 @@
   "author": "Santiago Ferreira",
   "license": "MIT",
   "devDependencies": {
-    "qunitjs": "^1.20.0"
+    "qunitjs": "^1.20.0",
+    "testem": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "license": "MIT",
   "devDependencies": {
     "qunitjs": "^1.20.0",
-    "testem": "^1.2.0"
+    "testem": "^1.1.0"
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -8,8 +8,12 @@
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
+  <script src="/testem.js" integrity="" ></script>
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
   <script src="../index.js"></script>
   <script src="tests.js"></script>
+  <script>
+    Testem.hookIntoTestFramework();
+  </script>
 </body>
 </html>

--- a/test/tests.js
+++ b/test/tests.js
@@ -10,7 +10,7 @@ test('evaluates a descriptor', function(assert) {
   var tree = Ceibo.create({
     key: {
       isDescriptor: true,
-      get() {
+      get: function() {
         return 'value';
       }
     }
@@ -34,7 +34,7 @@ test('process descriptors recursively', function(assert) {
     key: {
       anotherKey: {
         isDescriptor: true,
-        get() {
+        get: function() {
           return 'value';
         }
       }
@@ -59,8 +59,8 @@ test('overrides how strings are built', function(assert) {
     { key: "value" },
     {
       builder: {
-        string(treeBuilder, target, key, value) {
-          target[key] = `cuack ${value}`;
+        string: function(treeBuilder, target, key, value) {
+          target[key] = 'cuack ' + value;
         }
       }
     }
@@ -77,7 +77,7 @@ test('support value in descriptors', function(assert) {
         var copy = {};
 
         for (var attr in definition) {
-          copy[attr] = `${index} ${definition[attr]}`;
+          copy[attr] = index + ' ' + definition[attr];
         }
 
         return copy;
@@ -107,7 +107,7 @@ test('allows dynamic segments to process descriptors', function(assert) {
 
   var descriptor = {
     isDescriptor: true,
-    get() {
+    get: function() {
       return 'value';
     }
   };
@@ -155,8 +155,8 @@ test('descriptors can access current tree by default', function(assert) {
     foo: {
       isDescriptor: true,
 
-      get() {
-        return `The answer to life, the universe and everything is ${this.bar}`;
+      get: function() {
+        return 'The answer to life, the universe and everything is ' + this.bar;
       }
     },
 
@@ -178,11 +178,11 @@ test('descriptors can mutate tree on build', function(assert) {
     foo: {
       isDescriptor: true,
 
-      get() {
+      get: function() {
         return 'bar';
       },
 
-      setup(target, keyName) {
+      setup: function(target, keyName) {
         Ceibo.defineProperty(target, keyName.toUpperCase(), 'generated property');
       }
     }
@@ -191,7 +191,7 @@ test('descriptors can mutate tree on build', function(assert) {
   assert.equal(tree.FOO, 'generated property');
 });
 
-test('.creates asigns parent tree', function(assert) {
+test('.create asigns parent tree', function(assert) {
   var parentTree = Ceibo.create({ foo: { qux: 'another value' }, bar: 'a value' });
   var tree1 = Ceibo.create({ baz: {} }, { parent: parentTree });
   var tree2 = Ceibo.create({ baz: {} }, { parent: parentTree.foo });
@@ -200,7 +200,7 @@ test('.creates asigns parent tree', function(assert) {
   assert.equal(Ceibo.parent(tree2).qux, 'another value');
 });
 
-test(".creates doesn't assigns a parent tree to the root", function(assert) {
+test(".create doesn't assigns a parent tree to the root", function(assert) {
   var tree = Ceibo.create({ foo: 'a value' });
 
   assert.ok(!Ceibo.parent(tree));

--- a/testem.json
+++ b/testem.json
@@ -1,0 +1,15 @@
+{
+  "framework": "qunit",
+  "disable_watching": true,
+  "test_page": "test/index.html",
+  "src_files": [
+    "*.js",
+    "test/*.js"
+  ],
+  "launch_in_ci": [
+    "PhantomJS"
+  ],
+  "launch_in_dev": [
+    "PhantomJS"
+  ]
+}


### PR DESCRIPTION
Adds testem as a test runner. Run tests  PhantomJS with `npm test`.

(Note: To make tests work in PhantomJS, the tests had to be rewritten in ES5.)
