### PR TITLE
Expose default builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 npm-debug.log*
 node_modules
+.nvmrc
+testem.log

--- a/index.js
+++ b/index.js
@@ -128,12 +128,16 @@
   };
 
   var Ceibo = {
+    defaults: {
+      builder: DEFAULT_BUILDERS
+    },
+
     defineProperty: defineProperty,
 
     create: function(definition, options) {
       options = options || {};
 
-      var builder = merge(merge({}, DEFAULT_BUILDERS), options.builder);
+      var builder = merge(merge({}, this.defaults.builder), options.builder);
 
       return new TreeBuilder(definition, builder).build(options.parent);
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/san650/ceibo/issues",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node ./node_modules/testem/testem"
   },
   "repository": {
     "type": "git",
@@ -19,6 +19,7 @@
   "author": "Santiago Ferreira",
   "license": "MIT",
   "devDependencies": {
-    "qunitjs": "^1.20.0"
+    "qunitjs": "^1.20.0",
+    "testem": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "license": "MIT",
   "devDependencies": {
     "qunitjs": "^1.20.0",
-    "testem": "^1.2.0"
+    "testem": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ceibo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Ceibo is a JavaScript micro library to model trees that evaluate arbitrary code when accessing its nodes.",
   "homepage": "https://github.com/san650/ceibo#readme",
   "bugs": "https://github.com/san650/ceibo/issues",

--- a/test/index.html
+++ b/test/index.html
@@ -8,8 +8,12 @@
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
+  <script src="/testem.js" integrity="" ></script>
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
   <script src="../index.js"></script>
   <script src="tests.js"></script>
+  <script>
+    Testem.hookIntoTestFramework();
+  </script>
 </body>
 </html>

--- a/test/tests.js
+++ b/test/tests.js
@@ -10,7 +10,7 @@ test('evaluates a descriptor', function(assert) {
   var tree = Ceibo.create({
     key: {
       isDescriptor: true,
-      get() {
+      get: function() {
         return 'value';
       }
     }
@@ -34,7 +34,7 @@ test('process descriptors recursively', function(assert) {
     key: {
       anotherKey: {
         isDescriptor: true,
-        get() {
+        get: function() {
           return 'value';
         }
       }
@@ -59,8 +59,8 @@ test('overrides how strings are built', function(assert) {
     { key: "value" },
     {
       builder: {
-        string(treeBuilder, target, key, value) {
-          target[key] = `cuack ${value}`;
+        string: function(treeBuilder, target, key, value) {
+          target[key] = 'cuack ' + value;
         }
       }
     }
@@ -77,7 +77,7 @@ test('support value in descriptors', function(assert) {
         var copy = {};
 
         for (var attr in definition) {
-          copy[attr] = `${index} ${definition[attr]}`;
+          copy[attr] = index + ' ' + definition[attr];
         }
 
         return copy;
@@ -107,7 +107,7 @@ test('allows dynamic segments to process descriptors', function(assert) {
 
   var descriptor = {
     isDescriptor: true,
-    get() {
+    get: function() {
       return 'value';
     }
   };
@@ -155,8 +155,8 @@ test('descriptors can access current tree by default', function(assert) {
     foo: {
       isDescriptor: true,
 
-      get() {
-        return `The answer to life, the universe and everything is ${this.bar}`;
+      get: function() {
+        return 'The answer to life, the universe and everything is ' + this.bar;
       }
     },
 
@@ -178,11 +178,11 @@ test('descriptors can mutate tree on build', function(assert) {
     foo: {
       isDescriptor: true,
 
-      get() {
+      get: function() {
         return 'bar';
       },
 
-      setup(target, keyName) {
+      setup: function(target, keyName) {
         Ceibo.defineProperty(target, keyName.toUpperCase(), 'generated property');
       }
     }
@@ -191,7 +191,7 @@ test('descriptors can mutate tree on build', function(assert) {
   assert.equal(tree.FOO, 'generated property');
 });
 
-test('.creates asigns parent tree', function(assert) {
+test('.create asigns parent tree', function(assert) {
   var parentTree = Ceibo.create({ foo: { qux: 'another value' }, bar: 'a value' });
   var tree1 = Ceibo.create({ baz: {} }, { parent: parentTree });
   var tree2 = Ceibo.create({ baz: {} }, { parent: parentTree.foo });
@@ -200,7 +200,7 @@ test('.creates asigns parent tree', function(assert) {
   assert.equal(Ceibo.parent(tree2).qux, 'another value');
 });
 
-test(".creates doesn't assigns a parent tree to the root", function(assert) {
+test(".create doesn't assigns a parent tree to the root", function(assert) {
   var tree = Ceibo.create({ foo: 'a value' });
 
   assert.ok(!Ceibo.parent(tree));

--- a/test/tests.js
+++ b/test/tests.js
@@ -217,3 +217,17 @@ test(".parent doesn't generates enumerable attribute", function(assert) {
 
   assert.equal(Object.keys(tree.foo).length, 1);
 });
+
+test("default builders are exposed", function(assert) {
+  assert.expect(4);
+
+  var expectedKeys = ["descriptor", "object", "default"];
+
+  var defaults = Ceibo.defaults;
+
+  assert.equal(typeof defaults.builder, "object");
+
+  for (var i = 0; i < expectedKeys.length; i++) {
+    assert.equal(typeof defaults.builder[expectedKeys[i]], "function");
+  }
+});

--- a/testem.json
+++ b/testem.json
@@ -1,0 +1,15 @@
+{
+  "framework": "qunit",
+  "disable_watching": true,
+  "test_page": "test/index.html",
+  "src_files": [
+    "*.js",
+    "test/*.js"
+  ],
+  "launch_in_ci": [
+    "PhantomJS"
+  ],
+  "launch_in_dev": [
+    "PhantomJS"
+  ]
+}


### PR DESCRIPTION
Allows Ceibo users to create their own builders that invoke the default builders. (Kind of like using `super()`.)
